### PR TITLE
Add development and production modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,12 +232,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
    # Optional - Development
    DEBUG=true
    LOG_LEVEL=INFO
-   ENVIRONMENT=development
+   ENVIRONMENT=development  # or 'production'
    ```
 
 4. **Run Application**
    ```bash
-   streamlit run app_simple.py
+   ./start_app.sh                 # development (default)
+   ./start_app.sh production      # production mode
    ```
 
 ## 🎨 **Aurora Design System**

--- a/core/config.py
+++ b/core/config.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class AIProviderConfig:
     """Configuration for AI providers"""
+
     name: str
     api_key: Optional[str] = None
     base_url: Optional[str] = None
@@ -27,6 +28,7 @@ class AIProviderConfig:
 @dataclass
 class NotionConfig:
     """Configuration for Notion integration"""
+
     api_key: Optional[str] = None
     database_id: Optional[str] = None
     template_id: Optional[str] = None
@@ -35,77 +37,95 @@ class NotionConfig:
 @dataclass
 class Config:
     """Main configuration class"""
-    
+
     # File paths
     project_root: Path = field(default_factory=lambda: Path.cwd())
     data_dir: Path = field(default_factory=lambda: Path.cwd() / "data")
     prompts_dir: Path = field(default_factory=lambda: Path.cwd() / "prompts")
     temp_dir: Path = field(default_factory=lambda: Path.cwd() / "temp")
-    
+
     # AI Providers
     openai: AIProviderConfig = field(default_factory=lambda: AIProviderConfig("openai"))
-    anthropic: AIProviderConfig = field(default_factory=lambda: AIProviderConfig("anthropic"))
+    anthropic: AIProviderConfig = field(
+        default_factory=lambda: AIProviderConfig("anthropic")
+    )
     grok: AIProviderConfig = field(default_factory=lambda: AIProviderConfig("grok"))
-    
+
     # Integrations
     notion: NotionConfig = field(default_factory=NotionConfig)
-    
+
     # Processing settings
     audio_chunk_size_mb: int = 25
     max_tokens: int = 4000
     stream_responses: bool = True
-    
-    # UI settings
+
+    # Environment & UI settings
+    environment: str = "development"
     debug_mode: bool = False
     log_level: str = "INFO"
-    
+
+    @property
+    def is_development(self) -> bool:
+        """Check if running in development mode"""
+        return self.environment.lower() == "development"
+
+    @property
+    def is_production(self) -> bool:
+        """Check if running in production mode"""
+        return self.environment.lower() == "production"
+
     @classmethod
-    def from_env(cls) -> 'Config':
+    def from_env(cls) -> "Config":
         """Load configuration from environment variables"""
         config = cls()
-        
+
         # Load API keys from environment
         config.openai.api_key = os.getenv("OPENAI_API_KEY")
-        config.anthropic.api_key = os.getenv("ANTHROPIC_API_KEY") 
+        config.anthropic.api_key = os.getenv("ANTHROPIC_API_KEY")
         config.grok.api_key = os.getenv("GROK_API_KEY")
         config.notion.api_key = os.getenv("NOTION_API_KEY")
         config.notion.database_id = os.getenv("NOTION_DATABASE_ID")
-        
+
         # Load other settings
+        config.environment = os.getenv("ENVIRONMENT", "development")
         config.debug_mode = os.getenv("DEBUG", "false").lower() == "true"
-        config.log_level = os.getenv("LOG_LEVEL", "INFO")
-        
+        # Default log level varies by environment if not explicitly set
+        default_level = "DEBUG" if config.environment == "development" else "INFO"
+        config.log_level = os.getenv("LOG_LEVEL", default_level)
+
         return config
-    
+
     @classmethod
-    def from_file(cls, config_path: Path) -> 'Config':
+    def from_file(cls, config_path: Path) -> "Config":
         """Load configuration (simplified version without YAML)"""
         # For now, just use environment variables
-        logger.info("Using environment variables for configuration (YAML support disabled)")
+        logger.info(
+            "Using environment variables for configuration (YAML support disabled)"
+        )
         return cls.from_env()
-    
+
     def validate(self) -> bool:
         """Validate configuration"""
         errors = []
-        
+
         # Check for at least one AI provider
         if not any([self.openai.api_key, self.anthropic.api_key, self.grok.api_key]):
             errors.append("At least one AI provider API key is required")
-        
+
         # Validate directories exist or can be created
         for dir_path in [self.data_dir, self.prompts_dir, self.temp_dir]:
             try:
                 dir_path.mkdir(parents=True, exist_ok=True)
             except Exception as e:
                 errors.append(f"Cannot create directory {dir_path}: {e}")
-        
+
         if errors:
             for error in errors:
                 logger.error(error)
             return False
-        
+
         return True
-    
+
     def get_available_providers(self) -> list[str]:
         """Get list of available AI providers"""
         providers = []
@@ -133,4 +153,4 @@ def get_config() -> Config:
 def set_config(config: Config) -> None:
     """Set the global configuration instance"""
     global _config
-    _config = config 
+    _config = config

--- a/env.example
+++ b/env.example
@@ -11,7 +11,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
 
 # Application Settings
-ENVIRONMENT=development
+ENVIRONMENT=development  # or production
 DEBUG=true
 LOG_LEVEL=DEBUG
 

--- a/start_app.sh
+++ b/start_app.sh
@@ -20,9 +20,18 @@ if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
     echo "   export SUPABASE_ANON_KEY='<your-supabase-anon-key>'"
     exit 1
 fi
-export ENVIRONMENT="development"
-export DEBUG="true"
-export LOG_LEVEL="INFO"
+ENVIRONMENT="${1:-${ENVIRONMENT:-development}}"
+export ENVIRONMENT
+
+if [ "$ENVIRONMENT" = "production" ]; then
+  export DEBUG="${DEBUG:-false}"
+  export LOG_LEVEL="${LOG_LEVEL:-INFO}"
+else
+  export DEBUG="${DEBUG:-true}"
+  export LOG_LEVEL="${LOG_LEVEL:-DEBUG}"
+fi
+
+echo "Running in $ENVIRONMENT mode"
 
 echo "✅ Environment variables set"
 echo "🔗 Supabase URL: $SUPABASE_URL"

--- a/whisperforge_cli.py
+++ b/whisperforge_cli.py
@@ -17,14 +17,19 @@ sys.path.insert(0, str(project_root))
 
 # Import core functionality
 try:
-    from core.content_generation import transcribe_audio, generate_wisdom, generate_outline, generate_article
+    from core.content_generation import (
+        transcribe_audio,
+        generate_wisdom,
+        generate_outline,
+        generate_article,
+    )
     from core.logging_config import logger
     from core.utils import DEFAULT_PROMPTS
     from dotenv import load_dotenv
-    
+
     # Load environment variables
     load_dotenv()
-    
+
 except ImportError as e:
     print(f"Error importing WhisperForge modules: {e}")
     print("Make sure you're running this from the WhisperForge project directory.")
@@ -33,31 +38,31 @@ except ImportError as e:
 
 class CLIFile:
     """Simple file wrapper for CLI usage"""
-    
+
     def __init__(self, file_path: str):
         self.file_path = Path(file_path)
         self.name = self.file_path.name
         self.type = self._get_mime_type()
-    
+
     def _get_mime_type(self) -> str:
         """Get MIME type based on file extension"""
         ext = self.file_path.suffix.lower()
         mime_types = {
-            '.mp3': 'audio/mpeg',
-            '.wav': 'audio/wav',
-            '.m4a': 'audio/mp4',
-            '.aac': 'audio/aac',
-            '.ogg': 'audio/ogg',
-            '.flac': 'audio/flac',
-            '.webm': 'audio/webm'
+            ".mp3": "audio/mpeg",
+            ".wav": "audio/wav",
+            ".m4a": "audio/mp4",
+            ".aac": "audio/aac",
+            ".ogg": "audio/ogg",
+            ".flac": "audio/flac",
+            ".webm": "audio/webm",
         }
-        return mime_types.get(ext, 'audio/mpeg')
-    
+        return mime_types.get(ext, "audio/mpeg")
+
     def read(self) -> bytes:
         """Read file content"""
-        with open(self.file_path, 'rb') as f:
+        with open(self.file_path, "rb") as f:
             return f.read()
-    
+
     def getvalue(self) -> bytes:
         """Get file content (Streamlit compatibility)"""
         return self.read()
@@ -68,34 +73,52 @@ def validate_audio_file(file_path: str) -> bool:
     if not os.path.exists(file_path):
         click.echo(f"Error: File '{file_path}' does not exist.", err=True)
         return False
-    
-    supported_extensions = ['.mp3', '.wav', '.m4a', '.aac', '.ogg', '.flac', '.webm']
+
+    supported_extensions = [".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac", ".webm"]
     file_ext = Path(file_path).suffix.lower()
-    
+
     if file_ext not in supported_extensions:
-        click.echo(f"Error: Unsupported file format '{file_ext}'. Supported formats: {', '.join(supported_extensions)}", err=True)
+        click.echo(
+            f"Error: Unsupported file format '{file_ext}'. Supported formats: {', '.join(supported_extensions)}",
+            err=True,
+        )
         return False
-    
+
     return True
 
 
 def validate_api_keys() -> bool:
     """Validate that required API keys are available"""
-    openai_key = os.getenv('OPENAI_API_KEY')
-    anthropic_key = os.getenv('ANTHROPIC_API_KEY')
-    
+    openai_key = os.getenv("OPENAI_API_KEY")
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+
     if not openai_key and not anthropic_key:
-        click.echo("Error: No API keys found. Please set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable.", err=True)
+        click.echo(
+            "Error: No API keys found. Please set OPENAI_API_KEY or ANTHROPIC_API_KEY environment variable.",
+            err=True,
+        )
         return False
-    
+
     return True
 
 
 @click.group()
+@click.option(
+    "--env",
+    type=click.Choice(["development", "production"]),
+    help="Runtime environment",
+)
 @click.version_option(version="2.0.0", prog_name="WhisperForge CLI")
-def cli():
+def cli(env: str | None):
     """WhisperForge CLI - Transform audio into structured content"""
-    pass
+    if env:
+        os.environ["ENVIRONMENT"] = env
+        if env == "development":
+            os.environ.setdefault("DEBUG", "true")
+            os.environ.setdefault("LOG_LEVEL", "DEBUG")
+        else:
+            os.environ.setdefault("DEBUG", "false")
+            os.environ.setdefault("LOG_LEVEL", "INFO")
 
 
 @cli.group()
@@ -105,107 +128,131 @@ def pipeline():
 
 
 @pipeline.command()
-@click.option('--input', '-i', 'input_file', required=True, type=click.Path(exists=True), 
-              help='Input audio file path')
-@click.option('--model', '-m', default='gpt-4o', 
-              help='AI model to use (gpt-4o, gpt-4o-mini, claude-3-5-sonnet-20241022)')
-@click.option('--output', '-o', type=click.Path(), 
-              help='Output directory (default: current directory)')
-@click.option('--format', 'output_format', default='all', 
-              type=click.Choice(['transcript', 'wisdom', 'outline', 'article', 'all']),
-              help='Output format(s) to generate')
-@click.option('--verbose', '-v', is_flag=True, help='Verbose output')
-def run(input_file: str, model: str, output: Optional[str], output_format: str, verbose: bool):
+@click.option(
+    "--input",
+    "-i",
+    "input_file",
+    required=True,
+    type=click.Path(exists=True),
+    help="Input audio file path",
+)
+@click.option(
+    "--model",
+    "-m",
+    default="gpt-4o",
+    help="AI model to use (gpt-4o, gpt-4o-mini, claude-3-5-sonnet-20241022)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    help="Output directory (default: current directory)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="all",
+    type=click.Choice(["transcript", "wisdom", "outline", "article", "all"]),
+    help="Output format(s) to generate",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+def run(
+    input_file: str,
+    model: str,
+    output: Optional[str],
+    output_format: str,
+    verbose: bool,
+):
     """Run the complete WhisperForge pipeline on an audio file"""
-    
+
     if verbose:
         click.echo(f"🚀 Starting WhisperForge pipeline...")
         click.echo(f"Input file: {input_file}")
         click.echo(f"Model: {model}")
         click.echo(f"Output format: {output_format}")
-    
+
     # Validate inputs
     if not validate_audio_file(input_file):
         sys.exit(1)
-    
+
     if not validate_api_keys():
         sys.exit(1)
-    
+
     # Set up output directory
     if output:
         output_dir = Path(output)
         output_dir.mkdir(parents=True, exist_ok=True)
     else:
         output_dir = Path.cwd()
-    
+
     # Create CLI file wrapper
     audio_file = CLIFile(input_file)
-    
+
     try:
         # Step 1: Transcription
         click.echo("🎵 Transcribing audio...")
         transcript = transcribe_audio(audio_file)
-        
+
         if not transcript or "Error" in transcript:
             click.echo(f"❌ Transcription failed: {transcript}", err=True)
             sys.exit(1)
-        
+
         # Save transcript
         transcript_file = output_dir / f"{Path(input_file).stem}_transcript.txt"
-        with open(transcript_file, 'w', encoding='utf-8') as f:
+        with open(transcript_file, "w", encoding="utf-8") as f:
             f.write(transcript)
-        
+
         click.echo(f"✅ Transcript saved: {transcript_file}")
-        
-        if output_format == 'transcript':
+
+        if output_format == "transcript":
             click.echo(f"📄 Transcript preview: {transcript[:200]}...")
             return
-        
+
         # Step 2: Generate content based on format
         results = {}
-        
-        if output_format in ['wisdom', 'all']:
+
+        if output_format in ["wisdom", "all"]:
             click.echo("🧠 Generating wisdom extraction...")
-            wisdom = generate_wisdom(transcript, DEFAULT_PROMPTS['wisdom_extraction'])
+            wisdom = generate_wisdom(transcript, DEFAULT_PROMPTS["wisdom_extraction"])
             if wisdom and "Error" not in wisdom:
                 wisdom_file = output_dir / f"{Path(input_file).stem}_wisdom.md"
-                with open(wisdom_file, 'w', encoding='utf-8') as f:
+                with open(wisdom_file, "w", encoding="utf-8") as f:
                     f.write(wisdom)
-                results['wisdom'] = wisdom_file
+                results["wisdom"] = wisdom_file
                 click.echo(f"✅ Wisdom saved: {wisdom_file}")
-        
-        if output_format in ['outline', 'all']:
+
+        if output_format in ["outline", "all"]:
             click.echo("📋 Generating outline...")
-            outline = generate_outline(transcript, DEFAULT_PROMPTS['outline_creation'])
+            outline = generate_outline(transcript, DEFAULT_PROMPTS["outline_creation"])
             if outline and "Error" not in outline:
                 outline_file = output_dir / f"{Path(input_file).stem}_outline.md"
-                with open(outline_file, 'w', encoding='utf-8') as f:
+                with open(outline_file, "w", encoding="utf-8") as f:
                     f.write(outline)
-                results['outline'] = outline_file
+                results["outline"] = outline_file
                 click.echo(f"✅ Outline saved: {outline_file}")
-        
-        if output_format in ['article', 'all']:
+
+        if output_format in ["article", "all"]:
             click.echo("📝 Generating article...")
-            article = generate_article(transcript, DEFAULT_PROMPTS['article_writing'])
+            article = generate_article(transcript, DEFAULT_PROMPTS["article_writing"])
             if article and "Error" not in article:
                 article_file = output_dir / f"{Path(input_file).stem}_article.md"
-                with open(article_file, 'w', encoding='utf-8') as f:
+                with open(article_file, "w", encoding="utf-8") as f:
                     f.write(article)
-                results['article'] = article_file
+                results["article"] = article_file
                 click.echo(f"✅ Article saved: {article_file}")
-        
+
         # Summary
         click.echo("\n🎉 Pipeline completed successfully!")
         click.echo(f"📁 Output directory: {output_dir}")
         click.echo(f"📄 Transcript: {transcript_file}")
-        
+
         for content_type, file_path in results.items():
             click.echo(f"📝 {content_type.title()}: {file_path}")
-        
+
         # Show preview
         if verbose and transcript:
             click.echo(f"\n📄 Transcript preview:\n{transcript[:300]}...")
-        
+
     except Exception as e:
         logger.logger.error(f"CLI pipeline error: {e}")
         click.echo(f"❌ Pipeline failed: {e}", err=True)
@@ -213,43 +260,53 @@ def run(input_file: str, model: str, output: Optional[str], output_format: str, 
 
 
 @cli.command()
-@click.option('--input', '-i', 'input_file', required=True, type=click.Path(exists=True),
-              help='Input audio file path')
-@click.option('--output', '-o', type=click.Path(),
-              help='Output file path (default: input_name_transcript.txt)')
+@click.option(
+    "--input",
+    "-i",
+    "input_file",
+    required=True,
+    type=click.Path(exists=True),
+    help="Input audio file path",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    help="Output file path (default: input_name_transcript.txt)",
+)
 def transcribe(input_file: str, output: Optional[str]):
     """Transcribe audio file to text only"""
-    
+
     if not validate_audio_file(input_file):
         sys.exit(1)
-    
+
     if not validate_api_keys():
         sys.exit(1)
-    
+
     # Set up output file
     if output:
         output_file = Path(output)
     else:
         output_file = Path(f"{Path(input_file).stem}_transcript.txt")
-    
+
     # Create CLI file wrapper
     audio_file = CLIFile(input_file)
-    
+
     try:
         click.echo("🎵 Transcribing audio...")
         transcript = transcribe_audio(audio_file)
-        
+
         if not transcript or "Error" in transcript:
             click.echo(f"❌ Transcription failed: {transcript}", err=True)
             sys.exit(1)
-        
+
         # Save transcript
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(transcript)
-        
+
         click.echo(f"✅ Transcript saved: {output_file}")
         click.echo(f"📄 Preview: {transcript[:200]}...")
-        
+
     except Exception as e:
         logger.logger.error(f"CLI transcription error: {e}")
         click.echo(f"❌ Transcription failed: {e}", err=True)
@@ -261,38 +318,46 @@ def status():
     """Check system status and configuration"""
     click.echo("🔍 WhisperForge CLI Status")
     click.echo("=" * 30)
-    
+
+    env = os.getenv("ENVIRONMENT", "development")
+    click.echo(f"Environment: {env}")
+    click.echo(f"Debug: {os.getenv('DEBUG', 'false')}")
+    click.echo(f"Log Level: {os.getenv('LOG_LEVEL', 'INFO')}")
+
     # Check API keys
-    openai_key = os.getenv('OPENAI_API_KEY')
-    anthropic_key = os.getenv('ANTHROPIC_API_KEY')
-    
+    openai_key = os.getenv("OPENAI_API_KEY")
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+
     click.echo(f"OpenAI API Key: {'✅ Set' if openai_key else '❌ Not set'}")
     click.echo(f"Anthropic API Key: {'✅ Set' if anthropic_key else '❌ Not set'}")
-    
+
     # Check dependencies
     try:
         import openai
+
         click.echo("OpenAI library: ✅ Available")
     except ImportError:
         click.echo("OpenAI library: ❌ Not available")
-    
+
     try:
         import anthropic
+
         click.echo("Anthropic library: ✅ Available")
     except ImportError:
         click.echo("Anthropic library: ❌ Not available")
-    
+
     # Check audio processing
     try:
         from pydub import AudioSegment
+
         click.echo("Audio processing (pydub): ✅ Available")
     except ImportError:
         click.echo("Audio processing (pydub): ❌ Not available")
-    
+
     click.echo("\n💡 To get started:")
     click.echo("1. Set your API key: export OPENAI_API_KEY='your-key-here'")
     click.echo("2. Run: python whisperforge_cli.py pipeline run --input audio.mp3")
 
 
-if __name__ == '__main__':
-    cli() 
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- support environment modes in config
- update start script to accept mode
- update CLI with environment option and status info
- document ENVIRONMENT usage
- clarify example env file

## Testing
- `black core/config.py whisperforge_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_68640c5904348333801ebc459a582d23