### PR TITLE
Add test setup guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to WhisperForge
+
+Thank you for considering contributing to WhisperForge!
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Create a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+3. Install dependencies required for development and testing:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   You can also run `scripts/setup_test_env.sh` which performs these steps for you.
+4. Run the test suite to ensure everything works:
+   ```bash
+   pytest
+   ```
+
+Please submit pull requests from feature branches and ensure all tests pass.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ NOTION_DATABASE_ID=your_notion_database_id
 
 ## 🧪 Testing
 
+Before running tests, make sure all dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+You can also use the helper script `scripts/setup_test_env.sh` to create a
+virtual environment with the required packages.
+
 Run the test suite:
 
 ```bash

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# WhisperForge Test Environment Setup Script
+# This script creates a Python virtual environment and installs
+# the required dependencies for running tests.
+
+set -e
+
+if [ ! -f requirements.txt ]; then
+  echo "Run this script from the project root where requirements.txt is located." >&2
+  exit 1
+fi
+
+python -m venv venv
+# shellcheck disable=SC1091
+source venv/bin/activate
+pip install -r requirements.txt
+
+echo "✅ Test environment ready. Activate it with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with instructions for installing dependencies
- mention requirements and helper script in README testing section
- provide a simple `scripts/setup_test_env.sh` script for creating a venv

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_68641288fa648333bd3dc9760dfc55e1