### PR TITLE
Rename GROQ_API_KEY to GROK_API_KEY with compatibility

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZi
 # AI API Keys
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-GROQ_API_KEY=your_groq_api_key_here
+GROK_API_KEY=your_grok_api_key_here
 
 # Application Settings
 ENVIRONMENT=development

--- a/archived_old_version/old_docs/CLEAN_SETUP.md
+++ b/archived_old_version/old_docs/CLEAN_SETUP.md
@@ -39,7 +39,7 @@ Edit the `.env` file and replace the placeholder values:
 # Current .env has placeholders - you need to add real keys:
 OPENAI_API_KEY=sk-your-actual-openai-key-here
 ANTHROPIC_API_KEY=sk-ant-your-actual-anthropic-key-here
-GROQ_API_KEY=gsk_your-actual-groq-key-here  # Optional but recommended
+GROK_API_KEY=gsk_your-actual-grok-key-here  # Optional but recommended
 ```
 
 ## Step 3: Test Basic Functionality

--- a/archived_old_version/old_docs/WHISPERFORGE_AUDIT_2025.md
+++ b/archived_old_version/old_docs/WHISPERFORGE_AUDIT_2025.md
@@ -55,7 +55,7 @@ SUPABASE_KEY=[VALID TOKEN]
 # ❌ Needs Real Values
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-GROQ_API_KEY=your_groq_api_key_here
+GROK_API_KEY=your_grok_api_key_here
 ```
 
 ---
@@ -128,7 +128,7 @@ GROQ_API_KEY=your_groq_api_key_here
 # Required for basic functionality
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
-GROQ_API_KEY=gsk_...
+GROK_API_KEY=gsk_...
 ```
 
 ### **Priority 2: File Organization**

--- a/core/config.py
+++ b/core/config.py
@@ -67,7 +67,7 @@ class Config:
         # Load API keys from environment
         config.openai.api_key = os.getenv("OPENAI_API_KEY")
         config.anthropic.api_key = os.getenv("ANTHROPIC_API_KEY") 
-        config.grok.api_key = os.getenv("GROK_API_KEY")
+        config.grok.api_key = os.getenv("GROK_API_KEY") or os.getenv("GROQ_API_KEY")
         config.notion.api_key = os.getenv("NOTION_API_KEY")
         config.notion.database_id = os.getenv("NOTION_DATABASE_ID")
         

--- a/core/utils.py
+++ b/core/utils.py
@@ -138,8 +138,8 @@ def get_anthropic_client():
         return None
 
 def get_grok_api_key():
-    """Get Grok API key"""
-    return os.getenv("GROK_API_KEY")
+    """Get Grok API key with backward compatibility for GROQ_API_KEY"""
+    return os.getenv("GROK_API_KEY") or os.getenv("GROQ_API_KEY")
 
 def update_usage_tracking(duration_seconds: float):
     """Placeholder for usage tracking - implement as needed"""

--- a/env.example
+++ b/env.example
@@ -7,6 +7,9 @@ SUPABASE_KEY=your_supabase_anon_key_here
 
 # AI API Keys
 OPENAI_API_KEY=your_openai_api_key_here
+# Optional AI Providers
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+GROK_API_KEY=your_grok_api_key_here
 
 # Application Settings
 ENVIRONMENT=development

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def test_env():
         'SUPABASE_ANON_KEY': os.getenv('SUPABASE_ANON_KEY', 'test-anon-key'),
         'OPENAI_API_KEY': os.getenv('OPENAI_API_KEY', 'test-openai-key'),
         'ANTHROPIC_API_KEY': os.getenv('ANTHROPIC_API_KEY', 'test-anthropic-key'),
-        'GROQ_API_KEY': os.getenv('GROQ_API_KEY', 'test-groq-key'),
+        'GROK_API_KEY': os.getenv('GROK_API_KEY', os.getenv('GROQ_API_KEY', 'test-grok-key')),
         'TESTING': 'true'
     }
     


### PR DESCRIPTION
## Summary
- rename `GROQ_API_KEY` to `GROK_API_KEY` in env files and tests
- support backward compatibility in `core/config.py`
- update archived docs to use the new variable name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_6864127a0e188333adfada36171b7388